### PR TITLE
Provide workaround for lifetime bug in rustlang

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -192,7 +192,9 @@ impl<C> DeviceFlow<C>
                                     .collect::<String>()
                                     .as_ref())]);
 
-        match self.client.borrow_mut().post(FlowType::Device.as_ref())
+        // note: works around bug in rustlang
+        // https://github.com/rust-lang/rust/issues/22252
+        let ret = match self.client.borrow_mut().post(FlowType::Device.as_ref())
                .header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
                .body(&*req)
                .send() {
@@ -237,7 +239,9 @@ impl<C> DeviceFlow<C>
                 self.id = client_id.to_string();
                 Ok(pi)
             }
-        }
+        };
+
+        ret
     }
 
     /// If the first call is successful, this method may be called.


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/issues/22252, r-value temporaries
outlive the lifetimes of variables bound with let statements in a function
body. Because of this, device.rs fails to compile against newer rustc
nightlies.

This implements a simple workaround that binds the result of the match in
`request_code` to a local variable before returning it. This allows it to have
the same lifetime as `req` in one of the previous let bindings.