### PR TITLE
chore(dependencies): bump hyper version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 [dependencies]
 chrono = "*"
 time = "*"
-hyper = ">= 0.4.0"
+hyper = ">= 0.5.0"
 log = "*"
 mime = "*"
 url = "*"


### PR DESCRIPTION
yup-oauth2 no longer builds with hyper 0.4.0, due to the use of a
now-undefined macro