### PR TITLE
fix(serde): go back to serde 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "yup-oauth2"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Sebastian Thiel <byronimo@gmail.com>"]
 repository = "https://github.com/Byron/yup-oauth2"
 description = "A partial oauth2 implementation, providing the 'device' authorization flow"
@@ -15,11 +15,11 @@ chrono = ">= 0.2"
 log = ">= 0.3"
 mime = ">= 0.1"
 url = ">= 0.5"
-hyper = ">= 0.7.0"
+hyper = ">= 0.8.0"
 itertools = ">= 0.4"
-serde = ">= 0.6"
-serde_json = ">= 0.6"
-serde_macros = { version = ">= 0.6", optional = true }
+serde = "0.6.0"
+serde_json = "0.6.0"
+serde_macros = { version = "0.6.0", optional = true }
 
 [features]
 default = ["with_syntex"]
@@ -27,8 +27,8 @@ nightly = ["serde_macros"]
 with_syntex = ["serde_codegen", "syntex"]
 
 [build-dependencies]
-syntex = { version = ">= 0.2", optional = true }
-serde_codegen = { version = ">= 0.6", optional = true }
+syntex = { version = "=0.28.0", optional = true }
+serde_codegen = { version = "=0.6.13", optional = true }
 
 [dev-dependencies]
 getopts = "0.2"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+<a name="v0.5.6"></a>
+### v0.5.6 (2016-04-10)
+
+
+#### Bug Fixes
+
+* **serde:**  go back to serde 0.6 ([1f2f5b8f](https://github.com/Byron/yup-oauth2/commit/1f2f5b8f892ac280eb33a114b5e415f914454311))
+
+
+
 <a name="v0.5.5"></a>
 ### v0.5.5 (2016-02-07)
 


### PR DESCRIPTION
That way, google-apis-rs can compile once again.
If not done, yup-oauth ends up being compiled with
an older serde (the one of google-apis-rs, it seems), even
though its code was generated by a possibly newer serde.

Signed-off-by: Sebastian Thiel <sthiel@thoughtworks.com>