### PR TITLE
Code reorganization in order to better support more flows

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::convert::From;
 
 use authenticator_delegate::{AuthenticatorDelegate, PollError, PollInformation};
-use common::{RequestError, Token, FlowType, ApplicationSecret};
+use types::{RequestError, Token, FlowType, ApplicationSecret};
 use device::DeviceFlow;
 use installed::{InstalledFlow, InstalledFlowReturnMethod};
 use refresh::{RefreshResult, RefreshFlow};
@@ -368,8 +368,8 @@ pub enum Retry {
 mod tests {
     use super::*;
     use super::super::device::tests::MockGoogleAuth;
-    use super::super::common::tests::SECRET;
-    use super::super::common::ConsoleApplicationSecret;
+    use super::super::types::tests::SECRET;
+    use super::super::types::ConsoleApplicationSecret;
     use storage::MemoryStorage;
     use std::default::Default;
     use hyper;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -6,14 +6,13 @@ use std::cmp::min;
 use std::error::Error;
 use std::fmt;
 use std::convert::From;
-use std::io;
 
-use common::{Token, FlowType, ApplicationSecret};
-use device::{PollInformation, RequestError, DeviceFlow, PollError};
+use authenticator_delegate::{AuthenticatorDelegate, PollError, PollInformation};
+use common::{RequestError, Token, FlowType, ApplicationSecret};
+use device::DeviceFlow;
 use installed::{InstalledFlow, InstalledFlowReturnMethod};
 use refresh::{RefreshResult, RefreshFlow};
-use storage::{TokenStorage};
-use chrono::{DateTime, UTC, Local};
+use storage::TokenStorage;
 use std::time::Duration;
 use hyper;
 
@@ -61,9 +60,7 @@ impl StringError {
             error.push_str(&*d);
         }
 
-        StringError {
-            error: error,
-        }
+        StringError { error: error }
     }
 }
 
@@ -90,18 +87,17 @@ impl Error for StringError {
 /// if no user is involved.
 pub trait GetToken {
     fn token<'b, I, T>(&mut self, scopes: I) -> Result<Token, Box<Error>>
-        where   T: AsRef<str> + Ord + 'b,
-                I: IntoIterator<Item=&'b T>;
+        where T: AsRef<str> + Ord + 'b,
+              I: IntoIterator<Item = &'b T>;
 
     fn api_key(&mut self) -> Option<String>;
 }
 
 impl<D, S, C> Authenticator<D, S, C>
-    where  D: AuthenticatorDelegate,
-           S: TokenStorage,
-           C: BorrowMut<hyper::Client> {
-
-
+    where D: AuthenticatorDelegate,
+          S: TokenStorage,
+          C: BorrowMut<hyper::Client>
+{
     /// Returns a new `Authenticator` instance
     ///
     /// # Arguments
@@ -116,8 +112,11 @@ impl<D, S, C> Authenticator<D, S, C>
     ///                 required scopes. If unset, it will be derived from the secret.
     /// [dev-con]: https://console.developers.google.com
     pub fn new(secret: &ApplicationSecret,
-               delegate: D, client: C, storage: S, flow_type: Option<FlowType>)
-                                                     -> Authenticator<D, S, C> {
+               delegate: D,
+               client: C,
+               storage: S,
+               flow_type: Option<FlowType>)
+               -> Authenticator<D, S, C> {
         Authenticator {
             flow_type: flow_type.unwrap_or(FlowType::Device),
             delegate: delegate,
@@ -142,9 +141,7 @@ impl<D, S, C> Authenticator<D, S, C>
         }
 
         let mut flow = InstalledFlow::new(self.client.borrow_mut(), installed_type);
-        flow.obtain_token(&mut self.delegate,
-                          &self.secret,
-                          scopes.iter())
+        flow.obtain_token(&mut self.delegate, &self.secret, scopes.iter())
     }
 
     fn retrieve_device_token(&mut self, scopes: &Vec<&str>) -> Result<Token, Box<Error>> {
@@ -154,33 +151,36 @@ impl<D, S, C> Authenticator<D, S, C>
         let pi: PollInformation;
         loop {
             let res = flow.request_code(&self.secret.client_id,
-                                        &self.secret.client_secret, scopes.iter());
+                                        &self.secret.client_secret,
+                                        scopes.iter());
 
             pi = match res {
-                    Err(res_err) => {
-                        match res_err {
-                            RequestError::HttpError(err) => {
-                                match self.delegate.connection_error(&err) {
-                                    Retry::Abort|Retry::Skip => return Err(Box::new(StringError::from(&err as &Error))),
-                                    Retry::After(d) => sleep(d),
+                Err(res_err) => {
+                    match res_err {
+                        RequestError::HttpError(err) => {
+                            match self.delegate.connection_error(&err) {
+                                Retry::Abort | Retry::Skip => {
+                                    return Err(Box::new(StringError::from(&err as &Error)))
                                 }
-                            },
-                            RequestError::InvalidClient
-                            |RequestError::NegativeServerResponse(_, _)
-                            |RequestError::InvalidScope(_) => {
-                                let serr = StringError::from(res_err.to_string());
-                                self.delegate.request_failure(res_err);
-                                return Err(Box::new(serr))
+                                Retry::After(d) => sleep(d),
                             }
-                        };
-                        continue
-                    },
-                    Ok(pi) => {
-                        self.delegate.present_user_code(&pi);
-                        pi
-                    }
-                };
-            break
+                        }
+                        RequestError::InvalidClient |
+                        RequestError::NegativeServerResponse(_, _) |
+                        RequestError::InvalidScope(_) => {
+                            let serr = StringError::from(res_err.to_string());
+                            self.delegate.request_failure(res_err);
+                            return Err(Box::new(serr));
+                        }
+                    };
+                    continue;
+                }
+                Ok(pi) => {
+                    self.delegate.present_user_code(&pi);
+                    pi
+                }
+            };
+            break;
         }
 
         // PHASE 1: POLL TOKEN
@@ -191,50 +191,56 @@ impl<D, S, C> Authenticator<D, S, C>
                     match poll_err {
                         &&PollError::HttpError(ref err) => {
                             match self.delegate.connection_error(err) {
-                                Retry::Abort|Retry::Skip
-                                    => return Err(Box::new(StringError::from(err as &Error))),
+                                Retry::Abort | Retry::Skip => {
+                                    return Err(Box::new(StringError::from(err as &Error)))
+                                }
                                 Retry::After(d) => sleep(d),
                             }
-                        },
+                        }
                         &&PollError::Expired(ref t) => {
                             self.delegate.expired(t);
-                            return  Err(Box::new(StringError::from(pts)))
-                        },
+                            return Err(Box::new(StringError::from(pts)));
+                        }
                         &&PollError::AccessDenied => {
                             self.delegate.denied();
-                            return Err(Box::new(StringError::from(pts)))
-                        },
+                            return Err(Box::new(StringError::from(pts)));
+                        }
                     }; // end match poll_err
-                },
-                Ok(None) =>
-                        match self.delegate.pending(&pi) {
-                            Retry::Abort|Retry::Skip
-                                => return Err(Box::new(StringError::new("Pending authentication aborted".to_string(), None))),
-                            Retry::After(d) => sleep(min(d, pi.interval)),
-                        },
-                Ok(Some(token)) => return Ok(token)
+                }
+                Ok(None) => {
+                    match self.delegate.pending(&pi) {
+                        Retry::Abort | Retry::Skip => {
+                            return Err(Box::new(StringError::new("Pending authentication aborted"
+                                                                     .to_string(),
+                                                                 None)))
+                        }
+                        Retry::After(d) => sleep(min(d, pi.interval)),
+                    }
+                }
+                Ok(Some(token)) => return Ok(token),
             }
         }
     }
 }
 
 impl<D, S, C> GetToken for Authenticator<D, S, C>
-    where  D: AuthenticatorDelegate,
-           S: TokenStorage,
-           C: BorrowMut<hyper::Client> {
-
+    where D: AuthenticatorDelegate,
+          S: TokenStorage,
+          C: BorrowMut<hyper::Client>
+{
     /// Blocks until a token was retrieved from storage, from the server, or until the delegate
     /// decided to abort the attempt, or the user decided not to authorize the application.
     /// In any failure case, the delegate will be provided with additional information, and
     /// the caller will be informed about storage related errors.
     /// Otherwise it is guaranteed to be valid for the given scopes.
     fn token<'b, I, T>(&mut self, scopes: I) -> Result<Token, Box<Error>>
-        where   T: AsRef<str> + Ord + 'b,
-                I: IntoIterator<Item=&'b T> {
+        where T: AsRef<str> + Ord + 'b,
+              I: IntoIterator<Item = &'b T>
+    {
         let (scope_key, scopes) = {
             let mut sv: Vec<&str> = scopes.into_iter()
-                                  .map(|s|s.as_ref())
-                                  .collect::<Vec<&str>>();
+                .map(|s| s.as_ref())
+                .collect::<Vec<&str>>();
             sv.sort();
             let mut sh = SipHasher::new();
             &sv.hash(&mut sh);
@@ -251,9 +257,9 @@ impl<D, S, C> GetToken for Authenticator<D, S, C>
                         let mut rf = RefreshFlow::new(self.client.borrow_mut());
                         loop {
                             match *rf.refresh_token(self.flow_type,
-                                                   &self.secret.client_id,
-                                                   &self.secret.client_secret,
-                                                   &t.refresh_token) {
+                                                    &self.secret.client_id,
+                                                    &self.secret.client_secret,
+                                                    &t.refresh_token) {
                                 RefreshResult::Error(ref err) => {
                                     match self.delegate.connection_error(err) {
                                         Retry::Abort|Retry::Skip =>
@@ -262,21 +268,22 @@ impl<D, S, C> GetToken for Authenticator<D, S, C>
                                                                     None))),
                                         Retry::After(d) => sleep(d),
                                     }
-                                },
+                                }
                                 RefreshResult::RefreshError(ref err_str, ref err_description) => {
                                     self.delegate.token_refresh_failed(&err_str, &err_description);
-                                    let storage_err =
-                                        match self.storage.set(scope_key, &scopes, None) {
-                                            Ok(_) => String::new(),
-                                            Err(err) => err.to_string(),
-                                        };
-                                    return Err(Box::new(
-                                        StringError::new(storage_err + err_str, err_description.as_ref())))
-                                },
+                                    let storage_err = match self.storage
+                                        .set(scope_key, &scopes, None) {
+                                        Ok(_) => String::new(),
+                                        Err(err) => err.to_string(),
+                                    };
+                                    return Err(Box::new(StringError::new(storage_err + err_str,
+                                                                         err_description.as_ref())));
+                                }
                                 RefreshResult::Success(ref new_t) => {
                                     t = new_t.clone();
                                     loop {
-                                        if let Err(err) = self.storage.set(scope_key, &scopes, Some(t.clone())) {
+                                        if let Err(err) = self.storage
+                                            .set(scope_key, &scopes, Some(t.clone())) {
                                             match self.delegate.token_storage_failure(true, &err) {
                                                 Retry::Skip => break,
                                                 Retry::Abort => return Err(Box::new(err)),
@@ -298,16 +305,15 @@ impl<D, S, C> GetToken for Authenticator<D, S, C>
                 Ok(None) => {
                     // Nothing was in storage - get a new token
                     // get new token. The respective sub-routine will do all the logic.
-                    match
-                        match self.flow_type {
-                            FlowType::Device => self.retrieve_device_token(&scopes),
-                            FlowType::InstalledInteractive => self.do_installed_flow(&scopes),
-                            FlowType::InstalledRedirect(_) => self.do_installed_flow(&scopes),
-                        }
-                    {
+                    match match self.flow_type {
+                        FlowType::Device => self.retrieve_device_token(&scopes),
+                        FlowType::InstalledInteractive => self.do_installed_flow(&scopes),
+                        FlowType::InstalledRedirect(_) => self.do_installed_flow(&scopes),
+                    } {
                         Ok(token) => {
                             loop {
-                                if let Err(err) = self.storage.set(scope_key, &scopes, Some(token.clone())) {
+                                if let Err(err) = self.storage
+                                    .set(scope_key, &scopes, Some(token.clone())) {
                                     match self.delegate.token_storage_failure(true, &err) {
                                         Retry::Skip => break,
                                         Retry::Abort => return Err(Box::new(err)),
@@ -320,126 +326,31 @@ impl<D, S, C> GetToken for Authenticator<D, S, C>
                                 break;
                             }// end attempt to save
                             Ok(token)
-                        },
+                        }
                         Err(err) => Err(err),
                     }// end match token retrieve result
-                },
+                }
                 Err(err) => {
                     match self.delegate.token_storage_failure(false, &err) {
-                        Retry::Abort|Retry::Skip => Err(Box::new(err)),
+                        Retry::Abort | Retry::Skip => Err(Box::new(err)),
                         Retry::After(d) => {
                             sleep(d);
-                            continue
+                            continue;
                         }
                     }
-                },
-            }// end match
+                }
+            };// end match
         }// end loop
     }
 
     fn api_key(&mut self) -> Option<String> {
         if self.secret.client_id.len() == 0 {
-            return None
+            return None;
         }
         Some(self.secret.client_id.clone())
     }
 }
 
-
-
-/// A partially implemented trait to interact with the `Authenticator`
-///
-/// The only method that needs to be implemented manually is `present_user_code(...)`,
-/// as no assumptions are made on how this presentation should happen.
-pub trait AuthenticatorDelegate {
-
-    /// Called whenever there is an HttpError, usually if there are network problems.
-    ///
-    /// Return retry information.
-    fn connection_error(&mut self, &hyper::Error) -> Retry {
-        Retry::Abort
-    }
-
-    /// Called whenever we failed to retrieve a token or set a token due to a storage error.
-    /// You may use it to either ignore the incident or retry.
-    /// This can be useful if the underlying `TokenStorage` may fail occasionally.
-    /// if `is_set` is true, the failure resulted from `TokenStorage.set(...)`. Otherwise,
-    /// it was `TokenStorage.get(...)`
-    fn token_storage_failure(&mut self, is_set: bool, _: &Error) -> Retry {
-        let _ = is_set;
-        Retry::Abort
-    }
-
-    /// The server denied the attempt to obtain a request code
-    fn request_failure(&mut self, RequestError) {}
-
-    /// Called if the request code is expired. You will have to start over in this case.
-    /// This will be the last call the delegate receives.
-    /// Given `DateTime` is the expiration date
-    fn expired(&mut self, &DateTime<UTC>) {}
-
-    /// Called if the user denied access. You would have to start over.
-    /// This will be the last call the delegate receives.
-    fn denied(&mut self) {}
-
-    /// Called if we could not acquire a refresh token for a reason possibly specified
-    /// by the server.
-    /// This call is made for the delegate's information only.
-    fn token_refresh_failed(&mut self, error: &String, error_description: &Option<String>) {
-        { let _ = error; }
-        { let _ = error_description; }
-    }
-
-    /// Called as long as we are waiting for the user to authorize us.
-    /// Can be used to print progress information, or decide to time-out.
-    ///
-    /// If the returned `Retry` variant is a duration.
-    /// # Notes
-    /// * Only used in `DeviceFlow`. Return value will only be used if it
-    /// is larger than the interval desired by the server.
-    fn pending(&mut self,  &PollInformation) -> Retry {
-        Retry::After(Duration::from_secs(5))
-    }
-
-    /// The server has returned a `user_code` which must be shown to the user,
-    /// along with the `verification_url`.
-    /// # Notes
-    /// * Will be called exactly once, provided we didn't abort during `request_code` phase.
-    /// * Will only be called if the Authenticator's flow_type is `FlowType::Device`.
-    fn present_user_code(&mut self, pi: &PollInformation) {
-        println!("Please enter {} at {} and grant access to this application",
-                 pi.user_code,
-                 pi.verification_url);
-        println!("Do not close this application until you either denied or granted access.");
-        println!("You have time until {}.",
-                 pi.expires_at.with_timezone(&Local));
-    }
-
-    /// Only method currently used by the InstalledFlow.
-    /// We need the user to navigate to a URL using their browser and potentially paste back a code
-    /// (or maybe not). Whether they have to enter a code depends on the InstalledFlowReturnMethod
-    /// used.
-    fn present_user_url(&mut self, url: &String, need_code: bool) -> Option<String> {
-        if need_code {
-            println!("Please direct your browser to {}, follow the instructions and enter the \
-                      code displayed here: ",
-                     url);
-
-            let mut code = String::new();
-            io::stdin().read_line(&mut code).ok().map(|_| code)
-        } else {
-            println!("Please direct your browser to {} and follow the instructions displayed \
-                      there.",
-                     url);
-            None
-        }
-    }
-}
-
-/// Uses all default implementations by AuthenticatorDelegate, and makes the trait's
-/// implementation usable in the first place.
-pub struct DefaultAuthenticatorDelegate;
-impl AuthenticatorDelegate for DefaultAuthenticatorDelegate {}
 
 /// A utility type to indicate how operations DeviceFlowHelper operations should be retried
 pub enum Retry {
@@ -458,7 +369,7 @@ mod tests {
     use super::*;
     use super::super::device::tests::MockGoogleAuth;
     use super::super::common::tests::SECRET;
-    use super::super::common::{ConsoleApplicationSecret};
+    use super::super::common::ConsoleApplicationSecret;
     use storage::MemoryStorage;
     use std::default::Default;
     use hyper;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -370,6 +370,7 @@ mod tests {
     use super::super::device::tests::MockGoogleAuth;
     use super::super::types::tests::SECRET;
     use super::super::types::ConsoleApplicationSecret;
+    use authenticator_delegate::DefaultAuthenticatorDelegate;
     use storage::MemoryStorage;
     use std::default::Default;
     use hyper;

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -1,0 +1,153 @@
+use hyper;
+
+use std::fmt;
+use std::io;
+use std::error::Error;
+
+use authenticator::Retry;
+use common::RequestError;
+
+use chrono::{DateTime, Local, UTC};
+use std::time::Duration;
+
+/// Contains state of pending authentication requests
+#[derive(Clone, Debug, PartialEq)]
+pub struct PollInformation {
+    /// Code the user must enter ...
+    pub user_code: String,
+    /// ... at the verification URL
+    pub verification_url: String,
+
+    /// The `user_code` expires at the given time
+    /// It's the time the user has left to authenticate your application
+    pub expires_at: DateTime<UTC>,
+    /// The interval in which we may poll for a status change
+    /// The server responds with errors of we poll too fast.
+    pub interval: Duration,
+}
+
+impl fmt::Display for PollInformation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        writeln!(f, "Proceed with polling until {}", self.expires_at)
+    }
+}
+
+/// Encapsulates all possible results of a `poll_token(...)` operation
+#[derive(Debug)]
+pub enum PollError {
+    /// Connection failure - retry if you think it's worth it
+    HttpError(hyper::Error),
+    /// indicates we are expired, including the expiration date
+    Expired(DateTime<UTC>),
+    /// Indicates that the user declined access. String is server response
+    AccessDenied,
+}
+
+impl fmt::Display for PollError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            PollError::HttpError(ref err) => err.fmt(f),
+            PollError::Expired(ref date) => writeln!(f, "Authentication expired at {}", date),
+            PollError::AccessDenied => "Access denied by user".fmt(f),
+        }
+    }
+}
+
+
+
+/// A partially implemented trait to interact with the `Authenticator`
+///
+/// The only method that needs to be implemented manually is `present_user_code(...)`,
+/// as no assumptions are made on how this presentation should happen.
+pub trait AuthenticatorDelegate {
+    /// Called whenever there is an HttpError, usually if there are network problems.
+    ///
+    /// Return retry information.
+    fn connection_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever we failed to retrieve a token or set a token due to a storage error.
+    /// You may use it to either ignore the incident or retry.
+    /// This can be useful if the underlying `TokenStorage` may fail occasionally.
+    /// if `is_set` is true, the failure resulted from `TokenStorage.set(...)`. Otherwise,
+    /// it was `TokenStorage.get(...)`
+    fn token_storage_failure(&mut self, is_set: bool, _: &Error) -> Retry {
+        let _ = is_set;
+        Retry::Abort
+    }
+
+    /// The server denied the attempt to obtain a request code
+    fn request_failure(&mut self, RequestError) {}
+
+    /// Called if the request code is expired. You will have to start over in this case.
+    /// This will be the last call the delegate receives.
+    /// Given `DateTime` is the expiration date
+    fn expired(&mut self, &DateTime<UTC>) {}
+
+    /// Called if the user denied access. You would have to start over.
+    /// This will be the last call the delegate receives.
+    fn denied(&mut self) {}
+
+    /// Called if we could not acquire a refresh token for a reason possibly specified
+    /// by the server.
+    /// This call is made for the delegate's information only.
+    fn token_refresh_failed(&mut self, error: &String, error_description: &Option<String>) {
+        {
+            let _ = error;
+        }
+        {
+            let _ = error_description;
+        }
+    }
+
+    /// Called as long as we are waiting for the user to authorize us.
+    /// Can be used to print progress information, or decide to time-out.
+    ///
+    /// If the returned `Retry` variant is a duration.
+    /// # Notes
+    /// * Only used in `DeviceFlow`. Return value will only be used if it
+    /// is larger than the interval desired by the server.
+    fn pending(&mut self, &PollInformation) -> Retry {
+        Retry::After(Duration::from_secs(5))
+    }
+
+    /// The server has returned a `user_code` which must be shown to the user,
+    /// along with the `verification_url`.
+    /// # Notes
+    /// * Will be called exactly once, provided we didn't abort during `request_code` phase.
+    /// * Will only be called if the Authenticator's flow_type is `FlowType::Device`.
+    fn present_user_code(&mut self, pi: &PollInformation) {
+        println!("Please enter {} at {} and grant access to this application",
+                 pi.user_code,
+                 pi.verification_url);
+        println!("Do not close this application until you either denied or granted access.");
+        println!("You have time until {}.",
+                 pi.expires_at.with_timezone(&Local));
+    }
+
+    /// Only method currently used by the InstalledFlow.
+    /// We need the user to navigate to a URL using their browser and potentially paste back a code
+    /// (or maybe not). Whether they have to enter a code depends on the InstalledFlowReturnMethod
+    /// used.
+    fn present_user_url(&mut self, url: &String, need_code: bool) -> Option<String> {
+        if need_code {
+            println!("Please direct your browser to {}, follow the instructions and enter the \
+                      code displayed here: ",
+                     url);
+
+            let mut code = String::new();
+            io::stdin().read_line(&mut code).ok().map(|_| code)
+        } else {
+            println!("Please direct your browser to {} and follow the instructions displayed \
+                      there.",
+                     url);
+            None
+        }
+    }
+}
+
+/// Uses all default implementations by AuthenticatorDelegate, and makes the trait's
+/// implementation usable in the first place.
+pub struct DefaultAuthenticatorDelegate;
+impl AuthenticatorDelegate for DefaultAuthenticatorDelegate {}

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::error::Error;
 
 use authenticator::Retry;
-use common::RequestError;
+use types::RequestError;
 
 use chrono::{DateTime, Local, UTC};
 use std::time::Duration;

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,19 +1,19 @@
 use std::iter::IntoIterator;
 use std::time::Duration;
 use std::default::Default;
-use std::fmt;
 
 use hyper;
 use hyper::header::ContentType;
 use url::form_urlencoded;
 use itertools::Itertools;
 use serde_json as json;
-use chrono::{DateTime,UTC, self};
+use chrono::{self, UTC};
 use std::borrow::BorrowMut;
 use std::io::Read;
 use std::i64;
 
-use common::{Token, FlowType, Flow, JsonError};
+use common::{Token, FlowType, Flow, RequestError, JsonError};
+use authenticator_delegate::{PollError, PollInformation};
 
 pub const GOOGLE_TOKEN_URL: &'static str = "https://accounts.google.com/o/oauth2/token";
 
@@ -45,100 +45,9 @@ impl<C> Flow for DeviceFlow<C> {
         FlowType::Device
     }
 }
-
-
-/// Contains state of pending authentication requests
-#[derive(Clone, Debug, PartialEq)]
-pub struct PollInformation {
-    /// Code the user must enter ...
-    pub user_code: String,
-    /// ... at the verification URL
-    pub verification_url: String,
-
-    /// The `user_code` expires at the given time
-    /// It's the time the user has left to authenticate your application
-    pub expires_at: DateTime<UTC>,
-    /// The interval in which we may poll for a status change
-    /// The server responds with errors of we poll too fast.
-    pub interval: Duration,
-}
-
-impl fmt::Display for PollInformation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        writeln!(f, "Proceed with polling until {}", self.expires_at)
-    }
-}
-
-/// Encapsulates all possible results of the `request_token(...)` operation
-pub enum RequestError {
-    /// Indicates connection failure
-    HttpError(hyper::Error),
-    /// The OAuth client was not found
-    InvalidClient,
-    /// Some requested scopes were invalid. String contains the scopes as part of
-    /// the server error message
-    InvalidScope(String),
-    /// A 'catch-all' variant containing the server error and description
-    /// First string is the error code, the second may be a more detailed description
-    NegativeServerResponse(String, Option<String>),
-}
-
-impl From<JsonError> for RequestError {
-    fn from(value: JsonError) -> RequestError {
-        match &*value.error {
-            "invalid_client" => RequestError::InvalidClient,
-            "invalid_scope" => RequestError::InvalidScope(
-                        value.error_description.unwrap_or("no description provided".to_string())
-                               ),
-            _ => RequestError::NegativeServerResponse(value.error, value.error_description),
-        }
-    }
-}
-
-impl fmt::Display for RequestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            RequestError::HttpError(ref err) => err.fmt(f),
-            RequestError::InvalidClient => "Invalid Client".fmt(f),
-            RequestError::InvalidScope(ref scope)
-                => writeln!(f, "Invalid Scope: '{}'", scope),
-            RequestError::NegativeServerResponse(ref error, ref desc) => {
-                try!(error.fmt(f));
-                if let &Some(ref desc) = desc {
-                    try!(write!(f, ": {}", desc));
-                }
-                "\n".fmt(f)
-            },
-        }
-    }
-}
-
-/// Encapsulates all possible results of a `poll_token(...)` operation
-#[derive(Debug)]
-pub enum PollError {
-    /// Connection failure - retry if you think it's worth it
-    HttpError(hyper::Error),
-    /// indicates we are expired, including the expiration date
-    Expired(DateTime<UTC>),
-    /// Indicates that the user declined access. String is server response
-    AccessDenied,
-}
-
-impl fmt::Display for PollError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            PollError::HttpError(ref err) => err.fmt(f),
-            PollError::Expired(ref date)
-                => writeln!(f, "Authentication expired at {}", date),
-            PollError::AccessDenied => "Access denied by user".fmt(f),
-        }
-    }
-}
-
-
 impl<C> DeviceFlow<C>
-    where   C: BorrowMut<hyper::Client> {
-
+    where C: BorrowMut<hyper::Client>
+{
     /// # Examples
     /// ```test_harness
     /// extern crate hyper;
@@ -175,30 +84,36 @@ impl<C> DeviceFlow<C>
     /// * If called after a successful result was returned at least once.
     /// # Examples
     /// See test-cases in source code for a more complete example.
-    pub fn request_code<'b, T, I>(&mut self, client_id: &str, client_secret: &str, scopes: I)
-                                    -> Result<PollInformation, RequestError>
-                                    where T: AsRef<str> + 'b,
-                                          I: IntoIterator<Item=&'b T> {
+    pub fn request_code<'b, T, I>(&mut self,
+                                  client_id: &str,
+                                  client_secret: &str,
+                                  scopes: I)
+                                  -> Result<PollInformation, RequestError>
+        where T: AsRef<str> + 'b,
+              I: IntoIterator<Item = &'b T>
+    {
         if self.state.is_some() {
             panic!("Must not be called after we have obtained a token and have no error");
         }
 
         // note: cloned() shouldn't be needed, see issue
         // https://github.com/servo/rust-url/issues/81
-        let req = form_urlencoded::serialize(
-                  &[("client_id", client_id),
-                    ("scope", scopes.into_iter()
-                                    .map(|s| s.as_ref())
-                                    .intersperse(" ")
-                                    .collect::<String>()
-                                    .as_ref())]);
+        let req = form_urlencoded::serialize(&[("client_id", client_id),
+                                               ("scope",
+                                                scopes.into_iter()
+                                                   .map(|s| s.as_ref())
+                                                   .intersperse(" ")
+                                                   .collect::<String>()
+                                                   .as_ref())]);
 
         // note: works around bug in rustlang
         // https://github.com/rust-lang/rust/issues/22252
-        let ret = match self.client.borrow_mut().post(FlowType::Device.as_ref())
-               .header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
-               .body(&*req)
-               .send() {
+        let ret = match self.client
+            .borrow_mut()
+            .post(FlowType::Device.as_ref())
+            .header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
+            .body(&*req)
+            .send() {
             Err(err) => {
                 return Err(RequestError::HttpError(err));
             }
@@ -219,10 +134,8 @@ impl<C> DeviceFlow<C>
 
                 // check for error
                 match json::from_str::<JsonError>(&json_str) {
-                    Err(_) => {}, // ignore, move on
-                    Ok(res) => {
-                        return Err(RequestError::from(res))
-                    }
+                    Err(_) => {} // ignore, move on
+                    Ok(res) => return Err(RequestError::from(res)),
                 }
 
                 let decoded: JsonData = json::from_str(&json_str).unwrap();
@@ -231,7 +144,7 @@ impl<C> DeviceFlow<C>
                 let pi = PollInformation {
                     user_code: decoded.user_code,
                     verification_url: decoded.verification_url,
-                    expires_at: UTC::now() + chrono::Duration::seconds(decoded.expires_in), 
+                    expires_at: UTC::now() + chrono::Duration::seconds(decoded.expires_in),
                     interval: Duration::from_secs(i64::abs(decoded.interval) as u64),
                 };
                 self.state = Some(DeviceFlowState::Pending(pi.clone()));
@@ -265,33 +178,35 @@ impl<C> DeviceFlow<C>
     pub fn poll_token(&mut self) -> Result<Option<Token>, &PollError> {
         // clone, as we may re-assign our state later
         let pi = match self.state {
-            Some(ref s) =>
+            Some(ref s) => {
                 match *s {
                     DeviceFlowState::Pending(ref pi) => pi.clone(),
                     DeviceFlowState::Error => return Err(self.error.as_ref().unwrap()),
                     DeviceFlowState::Success(ref t) => return Ok(Some(t.clone())),
-                },
+                }
+            }
             _ => panic!("You have to call request_code() beforehand"),
         };
 
         if pi.expires_at <= UTC::now() {
             self.error = Some(PollError::Expired(pi.expires_at));
             self.state = Some(DeviceFlowState::Error);
-            return Err(&self.error.as_ref().unwrap())
+            return Err(&self.error.as_ref().unwrap());
         }
 
         // We should be ready for a new request
-        let req = form_urlencoded::serialize(
-                       &[("client_id", &self.id[..]),
-                         ("client_secret", &self.secret),
-                         ("code", &self.device_code),
-                         ("grant_type", "http://oauth.net/grant_type/device/1.0")]);
+        let req = form_urlencoded::serialize(&[("client_id", &self.id[..]),
+                                               ("client_secret", &self.secret),
+                                               ("code", &self.device_code),
+                                               ("grant_type",
+                                                "http://oauth.net/grant_type/device/1.0")]);
 
-        let json_str =
-            match self.client.borrow_mut().post(GOOGLE_TOKEN_URL)
-               .header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
-               .body(&*req)
-               .send() {
+        let json_str = match self.client
+            .borrow_mut()
+            .post(GOOGLE_TOKEN_URL)
+            .header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
+            .body(&*req)
+            .send() {
             Err(err) => {
                 self.error = Some(PollError::HttpError(err));
                 return Err(self.error.as_ref().unwrap());
@@ -305,18 +220,18 @@ impl<C> DeviceFlow<C>
 
         #[derive(Deserialize)]
         struct JsonError {
-            error: String
+            error: String,
         }
 
         match json::from_str::<JsonError>(&json_str) {
-            Err(_) => {}, // ignore, move on, it's not an error
+            Err(_) => {} // ignore, move on, it's not an error
             Ok(res) => {
                 match res.error.as_ref() {
                     "access_denied" => {
                         self.error = Some(PollError::AccessDenied);
                         self.state = Some(DeviceFlowState::Error);
-                        return Err(self.error.as_ref().unwrap())
-                    },
+                        return Err(self.error.as_ref().unwrap());
+                    }
                     "authorization_pending" => return Ok(None),
                     _ => panic!("server message '{}' not understood", res.error),
                 };
@@ -329,7 +244,7 @@ impl<C> DeviceFlow<C>
 
         let res = Ok(Some(t.clone()));
         self.state = Some(DeviceFlowState::Success(t));
-        return res
+        return res;
     }
 }
 
@@ -356,24 +271,23 @@ pub mod tests {
                                   \"verification_url\" : \"http://www.google.com/device\",\r\n\
                                   \"expires_in\" : 1800,\r\n\
                                   \"interval\" : 0\r\n\
-                                }".to_string());
+                                }"
+                .to_string());
 
             c.0.content.push("HTTP/1.1 200 OK\r\n\
                              Server: BOGUS\r\n\
                              \r\n\
                             {\r\n\
                                 \"error\" : \"authorization_pending\"\r\n\
-                            }".to_string());
+                            }"
+                .to_string());
 
-            c.0.content.push("HTTP/1.1 200 OK\r\n\
-                             Server: BOGUS\r\n\
-                             \r\n\
-                            {\r\n\
-                              \"access_token\":\"1/fFAGRNJru1FTz70BzhT3Zg\",\r\n\
-                              \"expires_in\":3920,\r\n\
-                              \"token_type\":\"Bearer\",\r\n\
-                              \"refresh_token\":\"1/6BMfW9j53gdGImsixUH6kU5RsR4zwI9lUVX-tqf8JXQ\"\r\n\
-                            }".to_string());
+            c.0.content.push("HTTP/1.1 200 OK\r\nServer: \
+                              BOGUS\r\n\r\n{\r\n\"access_token\":\"1/fFAGRNJru1FTz70BzhT3Zg\",\
+                              \r\n\"expires_in\":3920,\r\n\"token_type\":\"Bearer\",\
+                              \r\n\"refresh_token\":\
+                              \"1/6BMfW9j53gdGImsixUH6kU5RsR4zwI9lUVX-tqf8JXQ\"\r\n}"
+                .to_string());
             c
 
         }
@@ -400,18 +314,17 @@ pub mod tests {
         }
 
         match flow.poll_token() {
-            Ok(None) => {},
+            Ok(None) => {}
             _ => unreachable!(),
         }
 
-        let t =
-            match flow.poll_token() {
-                Ok(Some(t)) => {
-                    assert_eq!(t.access_token, "1/fFAGRNJru1FTz70BzhT3Zg");
-                    t
-                },
-                _ => unreachable!(),
-            };
+        let t = match flow.poll_token() {
+            Ok(Some(t)) => {
+                assert_eq!(t.access_token, "1/fFAGRNJru1FTz70BzhT3Zg");
+                t
+            }
+            _ => unreachable!(),
+        };
 
         // from now on, all calls will yield the same result
         // As our mock has only 3 items, we would panic on this call

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,7 +12,7 @@ use std::borrow::BorrowMut;
 use std::io::Read;
 use std::i64;
 
-use common::{Token, FlowType, Flow, RequestError, JsonError};
+use types::{Token, FlowType, Flow, RequestError, JsonError};
 use authenticator_delegate::{PollError, PollInformation};
 
 pub const GOOGLE_TOKEN_URL: &'static str = "https://accounts.google.com/o/oauth2/token";

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,34 @@
+#![allow(dead_code)]
+
+//! Helper functions allowing you to avoid writing boilerplate code for common operations, such as
+//! parsing JSON or reading files.
+
+// Copyright (c) 2016 Google Inc (lewinb@google.com).
+//
+// Refer to the project root for licensing information.
+
+use serde_json;
+use std::io;
+use std::fs;
+
+use types::ApplicationSecret;
+
+pub fn read_application_secret(file: &String) -> io::Result<ApplicationSecret> {
+    use std::io::Read;
+
+    let mut secret = String::new();
+    let mut file = try!(fs::OpenOptions::new().read(true).open(file));
+    try!(file.read_to_string(&mut secret));
+
+    parse_application_secret(&secret)
+}
+
+pub fn parse_application_secret(secret: &String) -> io::Result<ApplicationSecret> {
+    match serde_json::from_str(secret) {
+        Err(e) => {
+            Err(io::Error::new(io::ErrorKind::InvalidData,
+                               format!("Bad application secret: {}", e)))
+        }
+        Ok(decoded) => Ok(decoded),
+    }
+}

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -19,7 +19,7 @@ use serde_json::error;
 use url::form_urlencoded;
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
-use common::{ApplicationSecret, Token};
+use types::{ApplicationSecret, Token};
 use authenticator_delegate::AuthenticatorDelegate;
 
 const OOB_REDIRECT_URI: &'static str = "urn:ietf:wg:oauth:2.0:oob";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,18 @@
 //! as means to adhere to the protocol, and remain resilient to all kinds of errors
 //! that can occour on the way.
 //!
-//! The returned `Token` should be stored permanently to authorize future API requests.
+//! # Installed Flow Usage
+//! The `InstalledFlow` involves showing a URL to the user (or opening it in a browser)
+//! and then either prompting the user to enter a displayed code, or make the authorizing
+//! website redirect to a web server spun up by this library.
+//! In order to use the interactive method, use the `InstalledInteractive` `FlowType`;
+//! for the redirect method, use `InstalledRedirect`, with the port number to let the
+//! server listen on.
+//! You can implement your own `AuthenticatorDelegate` in order to customize the flow;
+//! the `InstalledFlow` uses the `present_user_url` method.
+//!
+//! The returned `Token` is stored permanently to authorize future API requests in the
+//! same scopes.
 //!
 //! ```test_harness,no_run
 //! #![cfg_attr(feature = "nightly", feature(custom_derive, custom_attribute, plugin))]

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -12,17 +12,19 @@ extern crate mime;
 extern crate url;
 extern crate itertools;
 
+mod authenticator_delegate;
+mod authenticator;
 mod device;
 mod storage;
 mod installed;
-mod helper;
 mod refresh;
 mod common;
 
-pub use device::{DeviceFlow, PollInformation, PollError};
+pub use device::DeviceFlow;
 pub use refresh::{RefreshFlow, RefreshResult};
 pub use common::{Token, FlowType, ApplicationSecret, ConsoleApplicationSecret, Scheme, TokenType};
 pub use installed::{InstalledFlow, InstalledFlowReturnMethod};
 pub use storage::{TokenStorage, NullStorage, MemoryStorage, DiskTokenStorage};
-pub use helper::{Authenticator, AuthenticatorDelegate,
-                 Retry, DefaultAuthenticatorDelegate, GetToken};
+pub use authenticator::{Authenticator, Retry, GetToken};
+pub use authenticator_delegate::{AuthenticatorDelegate, DefaultAuthenticatorDelegate, PollError,
+                                 PollInformation};

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -12,19 +12,21 @@ extern crate mime;
 extern crate url;
 extern crate itertools;
 
-mod authenticator_delegate;
 mod authenticator;
+mod authenticator_delegate;
 mod device;
-mod storage;
+mod helper;
 mod installed;
 mod refresh;
-mod common;
+mod storage;
+mod types;
 
 pub use device::DeviceFlow;
 pub use refresh::{RefreshFlow, RefreshResult};
-pub use common::{Token, FlowType, ApplicationSecret, ConsoleApplicationSecret, Scheme, TokenType};
+pub use types::{Token, FlowType, ApplicationSecret, ConsoleApplicationSecret, Scheme, TokenType};
 pub use installed::{InstalledFlow, InstalledFlowReturnMethod};
 pub use storage::{TokenStorage, NullStorage, MemoryStorage, DiskTokenStorage};
 pub use authenticator::{Authenticator, Retry, GetToken};
 pub use authenticator_delegate::{AuthenticatorDelegate, DefaultAuthenticatorDelegate, PollError,
                                  PollInformation};
+pub use helper::*;

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,4 +1,4 @@
-use common::{FlowType, JsonError};
+use types::{FlowType, JsonError};
 use device::GOOGLE_TOKEN_URL;
 
 use chrono::UTC;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,7 @@
-/*
- * partially (c) 2016 Google Inc. (Lewin Bormann, lewinb@google.com)
- *
- * See project root for licensing information.
- */
+// partially (c) 2016 Google Inc. (Lewin Bormann, lewinb@google.com)
+//
+// See project root for licensing information.
+//
 
 extern crate serde_json;
 
@@ -172,10 +171,10 @@ impl DiskTokenStorage {
         }
 
         let mut f = try!(fs::OpenOptions::new()
-                             .create(true)
-                             .write(true)
-                             .truncate(true)
-                             .open(&self.location));
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&self.location));
         f.write(serialized.as_ref()).map(|_| ())
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io;
 use std::io::{Read, Write};
 
-use common::Token;
+use types::Token;
 
 /// Implements a specialized storage to set and retrieve `Token` instances.
 /// The `scope_hash` represents the signature of the scopes for which the given token

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,7 +244,6 @@ pub struct ConsoleApplicationSecret {
     pub installed: Option<ApplicationSecret>,
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;


### PR DESCRIPTION
I found some of the modules having inconsistent or unfitting names, or being a sort of a grab bag.

Therefore -- sorry for this big change, but I think it simplifies finding things either me or users are looking for, as well as future extensions like the ServiceAccountFlow I'm working on :-)

The public interface is unchanged except for two new helper methods that users of the library used to have to implement themselves although they are the same for everyone.